### PR TITLE
Feat/history rents initial setup

### DIFF
--- a/backend-rental/AppRental/Controllers/OfferController.cs
+++ b/backend-rental/AppRental/Controllers/OfferController.cs
@@ -10,71 +10,31 @@ namespace AppRental.Controllers
     [Route("api/[controller]")]
     public class OfferController: ControllerBase
     {
-        private readonly IJwtService _jwtService;
-        private readonly IEmailService _emailService;
-        private readonly ILogger<OfferController> _logger;
         private readonly IOfferService _offerService;
         private readonly ICarService _carService;
-        private readonly IRentService _rentService;
         
-        public OfferController(IJwtService jwtService, IEmailService emailService, ILogger<OfferController> logger, IOfferService offerService, ICarService carService, IRentService rentService)
+        public OfferController(IOfferService offerService, ICarService carService)
         {
-            _jwtService = jwtService;
-            _emailService = emailService;
-            _logger = logger;
             _offerService = offerService;
             _carService = carService;
-            _rentService = rentService;
         }
 
         [HttpPost]
         public async Task<ActionResult<OfferDTO>> GetOffer(RequestDTO requestDTO)
         {
             var car = await _carService.GetByIdAsync(requestDTO.CarId);
-            if (car is not { Status: CarStatus.Available })
+            if (car == null)
             {
-                return NotFound("Car not found or already rented.");
+                return NotFound("Car not found");
+            }
+            if (car.Status != CarStatus.Available)
+            {
+                return BadRequest("Car already rented.");
             }
 
             var offer = await _offerService.CreateOffer(car);
             var offerDto = OfferDTO.FromOffer(offer); 
             return Ok(offerDto);
-        }
-        [HttpPost("create-rent")]
-        public async Task<ActionResult> CreateRent([FromQuery] int offerId, [FromBody] RentDTO rentDTO)
-        {
-            var offer = await _offerService.GetByIdAsync(offerId);
-            if(offer == null)
-            {
-                return BadRequest();
-            }
-
-            var rent = await _rentService.CreateRent(offer, rentDTO);
-
-            var confirmationLink = _jwtService.GenerateLink(rent.Id);
-            await _emailService.SendRentConfirmationEmailAsync(rent.Email, confirmationLink);
-
-            return Ok(new {RentId = rent.Id});
-        }
-
-        [Authorize]
-        [HttpGet("confirm-rent")]
-        public async Task<IActionResult> ConfirmRent(int rentId)
-        {
-            var rent = await _rentService.GetByIdAsync(rentId);
-            _logger.LogInformation("Rent id: {}", rent?.Id);
-            
-            if(rent == null)
-                return BadRequest("Rent not found");
-            if(rent.Confirmed)
-                return BadRequest("Rent has already been confirmed.");
-            
-            _logger.LogInformation("Offer id: {}", rent.Offer.Id);
-            _logger.LogInformation("Car id: {}", rent.Offer.Car.Id);
-            
-            await _rentService.ConfirmRent(rent);
-            
-            return Ok("Rent successfully confirmed. It should appear in your rents history in few minutes.");
         }
     }
 }

--- a/backend-rental/AppRental/Controllers/RentController.cs
+++ b/backend-rental/AppRental/Controllers/RentController.cs
@@ -1,0 +1,74 @@
+﻿using AppRental.DTO;
+using AppRental.Model;
+using AppRental.Services.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AppRental.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class RentController : ControllerBase
+{
+    private readonly IOfferService _offerService;
+    private readonly IRentService _rentService;
+    private readonly IJwtService _jwtService;
+    private readonly IEmailService _emailService;
+    private readonly ILogger<RentController> _logger;
+
+    public RentController(IOfferService offerService, IRentService rentService, IJwtService jwtService, IEmailService emailService, ILogger<RentController> logger)
+    {
+        _offerService = offerService;
+        _rentService = rentService;
+        _jwtService = jwtService;
+        _emailService = emailService;
+        _logger = logger;
+    }
+
+    [HttpPost("create-rent")]
+    public async Task<ActionResult> CreateRent([FromQuery] int offerId, [FromBody] RentDTO rentDTO)
+    {
+        var offer = await _offerService.GetByIdAsync(offerId);
+        if(offer == null)
+        {
+            return BadRequest();
+        }
+
+        var rent = await _rentService.CreateRent(offer, rentDTO);
+
+        var confirmationLink = _jwtService.GenerateLink(rent.Id);
+        await _emailService.SendRentConfirmationEmailAsync(rent.Email, confirmationLink);
+
+        return Ok(new {RentId = rent.Id});
+    }
+
+    [Authorize]
+    [HttpGet("confirm-rent")]
+    public async Task<IActionResult> ConfirmRent(int rentId)
+    {
+        var rent = await _rentService.GetByIdAsync(rentId);
+        _logger.LogInformation("Rent id: {}", rent?.Id);
+            
+        if(rent == null)
+            return NotFound("Rent not found");
+        if(rent.Status != RentStatus.New)
+            return BadRequest("Rent has already been confirmed.");
+            
+        _logger.LogInformation("Offer id: {}", rent.Offer.Id);
+        _logger.LogInformation("Car id: {}", rent.Offer.Car.Id);
+            
+        await _rentService.ConfirmRent(rent);
+            
+        return Ok("Rent successfully confirmed. It should appear in your rents history in few minutes.");
+    }
+
+    [HttpGet("status")]
+    public async Task<ActionResult<RentStatusDTO>> GetRentStatus([FromQuery] int rentId)
+    {
+        var rent = await _rentService.GetByIdAsync(rentId);
+        if (rent == null)
+            return NotFound("Rent not found");
+        var rentStatusDto = RentStatusDTO.FromRent(rent);
+        return Ok(rentStatusDto);
+    }
+}

--- a/backend-rental/AppRental/DTO/RentStatusDTO.cs
+++ b/backend-rental/AppRental/DTO/RentStatusDTO.cs
@@ -1,0 +1,16 @@
+﻿using AppRental.Model;
+
+namespace AppRental.DTO;
+
+public class RentStatusDTO
+{
+    public required string status;
+
+    public static RentStatusDTO FromRent(Rent rent)
+    {
+        return new RentStatusDTO
+        {
+            status = rent.Status.ToString()
+        };
+    }
+}

--- a/backend-rental/AppRental/Migrations/20241208142623_AddRentStatus.Designer.cs
+++ b/backend-rental/AppRental/Migrations/20241208142623_AddRentStatus.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using AppRental.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace AppRental.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20241208142623_AddRentStatus")]
+    partial class AddRentStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend-rental/AppRental/Migrations/20241208142623_AddRentStatus.cs
+++ b/backend-rental/AppRental/Migrations/20241208142623_AddRentStatus.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AppRental.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRentStatus : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Confirmed",
+                table: "Rents");
+
+            migrationBuilder.AddColumn<int>(
+                name: "Status",
+                table: "Rents",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Status",
+                table: "Rents");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Confirmed",
+                table: "Rents",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+    }
+}

--- a/backend-rental/AppRental/Model/Rent.cs
+++ b/backend-rental/AppRental/Model/Rent.cs
@@ -11,6 +11,15 @@ namespace AppRental.Model
         public DateTime StartDate { get; set; }
         public DateTime? EndDate { get; set; }
 
-        public bool Confirmed { get; set; } = false; 
+        public RentStatus Status { get; set; } = RentStatus.New; 
+        
+    }
+
+    public enum RentStatus
+    {
+        New, // Waiting for confirmation
+        Confirmed,
+        Returned, //  Waiting for employee approval
+        Finished
     }
 }

--- a/backend-rental/AppRental/Services/Implementations/JwtService.cs
+++ b/backend-rental/AppRental/Services/Implementations/JwtService.cs
@@ -34,7 +34,8 @@ namespace AppRental.Services.Implementations
         public string GenerateLink(int rentId)
         {
             var token = GenerateRentConfirmationToken();
-            return $"https://localhost:5001/api/offer/confirm-rent?rentId={rentId}&token={token}"; // hardcoded origin
+            // TODO: generate this url dynamically
+            return $"https://localhost:5001/api/rent/confirm-rent?rentId={rentId}&token={token}"; // hardcoded origin
         }
     }
 }

--- a/backend-rental/AppRental/Services/Implementations/RentService.cs
+++ b/backend-rental/AppRental/Services/Implementations/RentService.cs
@@ -36,7 +36,7 @@ public class RentService : IRentService
 
     public async Task ConfirmRent(Rent rent)
     {
-        rent.Confirmed = true;
+        rent.Status = RentStatus.Confirmed;
         rent.StartDate = DateTime.UtcNow;
         rent.Offer.Car.Status = CarStatus.Rented;
         await _context.SaveChangesAsync();

--- a/backend/AppBrowser/Services/Implementations/CarRentalExternalProviderService.cs
+++ b/backend/AppBrowser/Services/Implementations/CarRentalExternalProviderService.cs
@@ -84,7 +84,7 @@ public class CarRentalExternalProviderService : IExternalProviderService
         CarRentalExternalProviderCreateRentDto createRentDto, int offerId)
     {
         string url =
-            $"{_configuration.GetValue<string>("CarRentalBaseAPIUrl")}/api/offer/create-rent?offerId={offerId}";
+            $"{_configuration.GetValue<string>("CarRentalBaseAPIUrl")}/api/rent/create-rent?offerId={offerId}";
         var json = JsonSerializer.Serialize(createRentDto);
         var content = new StringContent(json, Encoding.UTF8, "application/json");
         var response = await _httpClient.PostAsync(url, content);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@hookform/resolvers": "^3.9.1",
         "@radix-ui/react-avatar": "^1.1.1",
         "@radix-ui/react-dialog": "^1.1.2",
+        "@radix-ui/react-dropdown-menu": "^2.1.2",
         "@radix-ui/react-icons": "^1.3.0",
         "@radix-ui/react-label": "^2.1.0",
         "@radix-ui/react-popover": "^1.1.2",
@@ -726,6 +727,21 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.0.tgz",
+      "integrity": "sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-dismissable-layer": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.1.tgz",
@@ -737,6 +753,35 @@
         "@radix-ui/react-primitive": "2.0.0",
         "@radix-ui/react-use-callback-ref": "1.1.0",
         "@radix-ui/react-use-escape-keydown": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.2.tgz",
+      "integrity": "sha512-GVZMR+eqK8/Kes0a36Qrv+i20bAPXSn8rCBTHx30w+3ECnR5o3xixAlqcVaYvLeyKUsm0aqyhWfmUcqufM8nYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-menu": "2.1.2",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -827,6 +872,46 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.2.tgz",
+      "integrity": "sha512-lZ0R4qR2Al6fZ4yCCZzu/ReTFrylHFxIqy7OezIpWF4bL0o9biKo0pFIvkaew3TyZ9Fy5gYVrR5zCGZBVbO1zg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-collection": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.1",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.0",
+        "@radix-ui/react-portal": "1.1.2",
+        "@radix-ui/react-presence": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-roving-focus": "1.1.0",
+        "@radix-ui/react-slot": "1.1.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.6.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -994,6 +1079,52 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.0.tgz",
+      "integrity": "sha512-EA6AMGeq9AEeQDeSH0aZgG198qkfHSbvWTf1HvoDmOB5bBG/qTxjYMWUKMnYiV6J/iP/J8MEFSuB2zRU2n7ODA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-collection": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-context": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.0.tgz",
+      "integrity": "sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-avatar": "^1.1.1",
     "@radix-ui/react-dialog": "^1.1.2",
+    "@radix-ui/react-dropdown-menu": "^2.1.2",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-popover": "^1.1.2",

--- a/frontend/src/app/rents-history/page.tsx
+++ b/frontend/src/app/rents-history/page.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { REACT_QUERY_USER_INFO_KEY } from "~/lib/consts";
+import { getUserInfo } from "~/api/getUserInfo";
+import { useQuery } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useToast } from "~/hooks/use-toast";
+import { useEffect, useState } from "react";
+import ErrorAlert from "~/components/ErrorAlert";
+import RentsHistory from "~/components/RentsHistory";
+
+const RentsHistoryPage = () => {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [isAccessDenied, setIsAccessDenied] = useState(false);
+
+  const { data: userData, isLoading: isUserDataLoading } = useQuery({
+    queryKey: [REACT_QUERY_USER_INFO_KEY],
+    queryFn: getUserInfo,
+  });
+
+  useEffect(() => {
+    if (!userData && !isUserDataLoading) {
+      toast({
+        title: "Unauthorized",
+        description:
+          "This page is only for authenticated users. You will be redirected to main page.",
+        variant: "destructive",
+      });
+      setTimeout(() => {
+        router.push("/");
+      }, 1000);
+      setIsAccessDenied(true);
+    }
+  }, [isUserDataLoading, userData, router, toast]);
+
+  if (isUserDataLoading) {
+    return (
+      <div className="flex w-full items-center justify-center py-5">
+        <Loader2 className="animate-spin" />
+      </div>
+    );
+  }
+
+  if (isAccessDenied) {
+    return (
+      <div className="mx-auto max-w-[350px] lg:max-w-[450px]">
+        <ErrorAlert
+          title="Access denied"
+          message="This page is for authenticated users only."
+        />
+      </div>
+    );
+  }
+
+  return <RentsHistory />;
+};
+
+export default RentsHistoryPage;

--- a/frontend/src/components/FinishedRentCard.tsx
+++ b/frontend/src/components/FinishedRentCard.tsx
@@ -1,0 +1,5 @@
+const FinishedRentCard = () => {
+  return <div>finished</div>;
+};
+
+export default FinishedRentCard;

--- a/frontend/src/components/OngoingRentCard.tsx
+++ b/frontend/src/components/OngoingRentCard.tsx
@@ -1,0 +1,5 @@
+const OngoingRentCard = () => {
+  return <div>ongoing</div>;
+};
+
+export default OngoingRentCard;

--- a/frontend/src/components/RentsHistory.tsx
+++ b/frontend/src/components/RentsHistory.tsx
@@ -1,0 +1,5 @@
+const RentsHistory = () => {
+  return <div className="my-10 flex w-full items-center justify-center"></div>;
+};
+
+export default RentsHistory;

--- a/frontend/src/components/UserInfo.tsx
+++ b/frontend/src/components/UserInfo.tsx
@@ -30,6 +30,7 @@ const UserInfo = () => {
   const handleLogout = () => {
     sessionStorage.removeItem(TOKEN_KEY);
     queryClient.removeQueries({ queryKey: [REACT_QUERY_USER_INFO_KEY] });
+    router.push("/");
     router.refresh();
   };
 
@@ -47,7 +48,9 @@ const UserInfo = () => {
           <DropdownMenuLabel>My Account</DropdownMenuLabel>
           <DropdownMenuSeparator />
           <DropdownMenuGroup>
-            <DropdownMenuItem>Rents History</DropdownMenuItem>
+            <DropdownMenuItem onClick={() => router.push("/rents-history")}>
+              Rents History
+            </DropdownMenuItem>
           </DropdownMenuGroup>
           <DropdownMenuSeparator />
           <DropdownMenuItem onClick={() => handleLogout()}>

--- a/frontend/src/components/UserInfo.tsx
+++ b/frontend/src/components/UserInfo.tsx
@@ -1,10 +1,23 @@
 import LoginDialogButton from "./LoginDialogButton";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getUserInfo } from "~/api/getUserInfo";
 import { Avatar, AvatarFallback } from "~/components/ui/avatar";
-import { REACT_QUERY_USER_INFO_KEY } from "~/lib/consts";
+import { REACT_QUERY_USER_INFO_KEY, TOKEN_KEY } from "~/lib/consts";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "~/components/ui/dropdown-menu";
+import { useRouter } from "next/navigation";
 
 const UserInfo = () => {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
   const { data } = useQuery({
     queryKey: [REACT_QUERY_USER_INFO_KEY],
     queryFn: getUserInfo,
@@ -14,15 +27,34 @@ const UserInfo = () => {
     return <LoginDialogButton />;
   }
 
-  // TODO: add some profile options on avatar click
+  const handleLogout = () => {
+    sessionStorage.removeItem(TOKEN_KEY);
+    queryClient.removeQueries({ queryKey: [REACT_QUERY_USER_INFO_KEY] });
+    router.refresh();
+  };
 
   return (
     <div className="flex flex-row">
-      <Avatar>
-        <AvatarFallback>
-          {data?.firstName[0]?.toUpperCase() ?? ""}
-        </AvatarFallback>
-      </Avatar>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Avatar className="hover:cursor-pointer">
+            <AvatarFallback>
+              {data?.firstName[0]?.toUpperCase() ?? ""}
+            </AvatarFallback>
+          </Avatar>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuLabel>My Account</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuGroup>
+            <DropdownMenuItem>Rents History</DropdownMenuItem>
+          </DropdownMenuGroup>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onClick={() => handleLogout()}>
+            Log out
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   );
 };

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,200 @@
+"use client"
+
+import * as React from "react"
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
+import { cn } from "~/lib/utils"
+import { CheckIcon, ChevronRightIcon, DotFilledIcon } from "@radix-ui/react-icons"
+
+const DropdownMenu = DropdownMenuPrimitive.Root
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+
+const DropdownMenuGroup = DropdownMenuPrimitive.Group
+
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal
+
+const DropdownMenuSub = DropdownMenuPrimitive.Sub
+
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup
+
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRightIcon className="ml-auto" />
+  </DropdownMenuPrimitive.SubTrigger>
+))
+DropdownMenuSubTrigger.displayName =
+  DropdownMenuPrimitive.SubTrigger.displayName
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuSubContent.displayName =
+  DropdownMenuPrimitive.SubContent.displayName
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+))
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
+
+const DropdownMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <CheckIcon className="h-4 w-4" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+))
+DropdownMenuCheckboxItem.displayName =
+  DropdownMenuPrimitive.CheckboxItem.displayName
+
+const DropdownMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <DotFilledIcon className="h-2 w-2 fill-current" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+))
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      "px-2 py-1.5 text-sm font-semibold",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+))
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
+
+const DropdownMenuShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
+      {...props}
+    />
+  )
+}
+DropdownMenuShortcut.displayName = "DropdownMenuShortcut"
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuRadioGroup,
+}

--- a/frontend/src/responses/IRentsHistoryListReponse.ts
+++ b/frontend/src/responses/IRentsHistoryListReponse.ts
@@ -1,0 +1,8 @@
+import { type ISingleRentHistoryReponse } from "./ISingleRentHistoryResponse";
+
+export interface IRentsHistoryListResponse {
+  data: ISingleRentHistoryReponse[];
+  count: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}

--- a/frontend/src/responses/ISingleRentHistoryResponse.ts
+++ b/frontend/src/responses/ISingleRentHistoryResponse.ts
@@ -1,0 +1,12 @@
+import { type ISingleCarResponse } from "./ISignleCarResponse";
+
+export interface ISingleRentHistoryReponse {
+  rentId: number;
+  providerId: number;
+  costPerDay: number;
+  insuranceCostPerDay: number;
+  startDate: string;
+  endDate?: string;
+  isFinished: boolean;
+  carData: ISingleCarResponse;
+}


### PR DESCRIPTION
Content of this PR:
- added `RentStatus` column to Rent
- added endpoint for returning rent status on backend-rental
- move rent logic to `RentController` on backend-rental
- setup `Rents History` mock page on frontend
- added logout logic on frontend